### PR TITLE
Copy properties after cloning node

### DIFF
--- a/iron-swiper.html
+++ b/iron-swiper.html
@@ -394,7 +394,7 @@ Polymer 2.x element that wraps around Swiper.js
               slides[i].classList.add('swiper-no-swiping');
             }
 
-            var node = wrapper.appendChild(slides[i].cloneNode(true));
+            const node = wrapper.appendChild(slides[i].cloneNode(true));
             this._copyProperties(slides[i], node);
             node.classList.add('swiper-slide');
             node.setAttribute('index', i.toString());

--- a/iron-swiper.html
+++ b/iron-swiper.html
@@ -359,18 +359,17 @@ Polymer 2.x element that wraps around Swiper.js
         clearTimeout(this._initializer);
         this._initializer = setTimeout(function() {
           // First clone real nodes into the wrapper
-          var _nodes = [];
-
+          const _nodes = [];
+          const excludeTagNames = ['TEMPLATE', 'DOM-REPEAT', 'DOM-IF'];
           let slides = Polymer.FlattenedNodesObserver.getFlattenedNodes(this)
             .filter(
               function(node) {
                 return node.tagName &&
-                node.tagName !== 'TEMPLATE' &&
+                excludeTagNames.indexOf(node.tagName) === -1 &&
                 !node.classList.contains('swiper-slide');
               });
 
-          var wrapper = this.$.wrapper;
-
+          const wrapper = this.$.wrapper;
           wrapper.innerHTML = '';
           wrapper.removeAttribute('style');
 
@@ -432,7 +431,6 @@ Polymer 2.x element that wraps around Swiper.js
         }
 
         this._swiper = new window.Swiper(this.$.swiper, this.getOptions());
-        // this.scopeSubtree(this.$.swiper); // for polymer 2.x this process should be automatic now. See https://github.com/webcomponents/shadycss/issues/114#issuecomment-321936467
       }
 
       _nodeClicked(e) {

--- a/iron-swiper.html
+++ b/iron-swiper.html
@@ -351,6 +351,10 @@ Polymer 2.x element that wraps around Swiper.js
         e.preventDefault();
       }
 
+      _copyProperties(node1, node2) {
+        Object.keys(node1.constructor.properties).forEach(key => node2[key] = node1[key]);
+      }
+
       init() {
         clearTimeout(this._initializer);
         this._initializer = setTimeout(function() {
@@ -377,6 +381,7 @@ Polymer 2.x element that wraps around Swiper.js
             }
 
             var node = wrapper.appendChild(slides[i].cloneNode(true));
+            this._copyProperties(slides[i], node);
             node.classList.add('swiper-slide');
             node.setAttribute('index', i.toString());
             node.removeEventListener('click', this._nodeClicked);


### PR DESCRIPTION
Fixing this use case:

```
<iron-swiper pagination>
  <template is="dom-repeat" items="[[items]]">
	<swiper-item item="[[item]]"></mg-swiper>
  </template>
</iron-swiper>
```

Before, `item` property would always be the default value because the node gets cloned.